### PR TITLE
Skip minor versions in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ greater depth than the [larod](https://github.com/AxisCommunications/acap3-examp
 and [vdo-larod](https://github.com/AxisCommunications/acap3-examples/tree/master/vdo-larod) examples.
 
 ### DockerHub Images
-There are two types of Docker images here: the toolchain (SDK), and the API 3.1. These images can be used as the basis for custom built images for running your applications. The images needed are specified in the docker-compose files. All images are public and free to use for anyone.
-* [Toolchain](https://hub.docker.com/repository/docker/axisecp/acap-toolchain) -  An Ubuntu-based toolchain bundle with all tools for building and packaging an ACAP 3.1 application included.
-* [API 3.1](https://hub.docker.com/repository/docker/axisecp/acap-api) - An Ubuntu-based API bundle with all API components (header and library files) included.
+There are two types of Docker images here: the toolchain (SDK), and the API. These images can be used as the basis for custom built images for running your applications. The images needed are specified in the docker-compose files. All images are public and free to use for anyone.
+* [Toolchain](https://hub.docker.com/repository/docker/axisecp/acap-toolchain) -  An Ubuntu-based toolchain bundle with all tools for building and packaging an ACAP 3 application included.
+* [API](https://hub.docker.com/repository/docker/axisecp/acap-api) - An Ubuntu-based API bundle with all API components (header and library files) included.
 
  # Frequently asked questions
 Please visit [FAQs page](FAQs.md)  for frequently asked questions.


### PR DESCRIPTION
Remove 3.1 so we don't have to update minor version for API images