### PR TITLE
set LAROD_API_VERSION_1 larod 1.x examples (#39)

### DIFF
--- a/larod/app/Makefile
+++ b/larod/app/Makefile
@@ -5,6 +5,9 @@ LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config \
             --libs $(DEPS))
 CFLAGS += -Wall -Wextra -Werror
 
+# This example is based on larod version 1
+CFLAGS += -DLAROD_API_VERSION_1
+
 .PHONY: all
 all: larod_simple_app model/mobilenet_v1_1.0_224_quant.larod
 

--- a/tensorflow-to-larod/env/app/Makefile
+++ b/tensorflow-to-larod/env/app/Makefile
@@ -13,6 +13,8 @@ CFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags $(PKGS)
 LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs $(PKGS))
 
 CFLAGS += -Wall
+# This example is based on larod version 1
+CFLAGS += -DLAROD_API_VERSION_1
 
 all:	$(PROGS) \
 		model/converted_model.larod

--- a/vdo-larod/app/Makefile
+++ b/vdo-larod/app/Makefile
@@ -13,6 +13,8 @@ CFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags $(PKGS)
 LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs $(PKGS))
 
 CFLAGS += -Wall
+# This example is based on larod version 1
+CFLAGS += -DLAROD_API_VERSION_1
 
 all:	$(PROGS) \
 		model/mobilenet_v2_1.0_224_quant.larod \


### PR DESCRIPTION
* set LAROD_API_VERSION_1 larod 1.x examples

* skip space before define

Co-authored-by: Petter Wallin <petterwa@axis.com>