### PR TITLE
Fixed build error for using-opencv (#44)

### DIFF
--- a/using-opencv/Dockerfile
+++ b/using-opencv/Dockerfile
@@ -64,11 +64,7 @@ RUN cmake -D CMAKE_TOOLCHAIN_FILE=../platforms/linux/arm-gnueabi.toolchain.cmake
 
 # Build openCV libraries and other tools
 RUN make -j 2 install
-RUN ln -sf $TARGET_ROOT/usr/include/opencv4/opencv2 $TARGET_ROOT/usr/include/opencv2
 
-# Build the application
-ARG PKG_ARCH=cortexa9hf-neon-poky-linux-gnueabi
-RUN cp -r /target-root/* /opt/axis/acapsdk/sysroots/cortexa9hf-neon-poky-linux-gnueabi/
 COPY app/ /build/src/
 WORKDIR /build/src
 RUN cp /opt/axis/acapsdk/sysroots/x86_64-pokysdk-linux/usr/bin/create-package.sh .

--- a/using-opencv/app/Makefile
+++ b/using-opencv/app/Makefile
@@ -8,14 +8,12 @@ STRIP = arm-linux-gnueabihf-strip
 PKGS = gio-2.0 vdostream gio-unix-2.0
 
 LDFLAGS += -L$(SDKTARGETSYSROOT)/usr/lib
-
 LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs $(PKGS))
+CXXFLAGS += -Os -pipe -std=c++11
+CXXFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags-only-I $(PKGS))
+CXXFLAGS += -I/target-root/usr/include/opencv4
 
-INCLUDES = -I. -I$(SDKTARGETSYSROOT)/usr/include/vdo -I$(SDKTARGETSYSROOT)/usr/include/glib-2.0 -I$(SDKTARGETSYSROOT)/usr/lib/glib-2.0/include
-
-CXXFLAGS += -Os -pipe -std=c++11 $(INCLUDES)
-
-SDK_TARGET_LIBS=$(SDKTARGETSYSROOT)/usr/lib
+SDK_TARGET_LIBS=$(TARGET_ROOT)/usr/lib
 
 SHLIB_DIR = ./lib
 


### PR DESCRIPTION
SDK path has changed in ACAP 3.3. Adjusted Dockerfile and Makefile for
open-usingcv so it doesn't depend on specific path for SDK.
