### PR TITLE
Use /bin/sh where bash is not needed and parallelize builds

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,6 +28,7 @@ jobs:
           VALIDATE_BASH: true
           VALIDATE_DOCKERFILE_HADOLINT: true
           VALIDATE_MARKDOWN: true
+          VALIDATE_SHELL_SHFMT: true
           VALIDATE_YAML: true
 
       - name: Check that linter symbolic links exist in top directory

--- a/LINT.md
+++ b/LINT.md
@@ -29,6 +29,7 @@ docker run --rm \
   -e VALIDATE_BASH=true \
   -e VALIDATE_DOCKERFILE_HADOLINT=true \
   -e VALIDATE_MARKDOWN=true \
+  -e VALIDATE_SHELL_SHFMT=true \
   -e VALIDATE_YAML=true \
   github/super-linter:slim-v4
 ```

--- a/object-detection/Dockerfile
+++ b/object-detection/Dockerfile
@@ -16,7 +16,7 @@ RUN git checkout ${libyuv_version}
 COPY yuv/*.patch /opt/build/libyuv
 RUN git apply ./*.patch && \
     CXXFLAGS=' -O2 -mthumb -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9 -fomit-frame-pointer' \
-    make -f linux.mk CXX=arm-linux-gnueabihf-g++ CC=arm-linux-gnueabihf-gcc && \
+    make -j -f linux.mk CXX=arm-linux-gnueabihf-g++ CC=arm-linux-gnueabihf-gcc && \
     arm-linux-gnueabihf-strip --strip-unneeded libyuv.so*
 
 # Build libjpeg-turbo
@@ -28,7 +28,7 @@ RUN git clone --branch 2.0.6 https://github.com/libjpeg-turbo/libjpeg-turbo.git
 WORKDIR /opt/build/libjpeg-turbo/build
 RUN CFLAGS=' -O2 -mthumb -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9 -fomit-frame-pointer' \
     CC=arm-linux-gnueabihf-gcc cmake -G"Unix Makefiles" .. && \
-    make
+    make -j
 WORKDIR /opt/app
 RUN mkdir -p lib include && \
     cp /opt/build/libjpeg-turbo/build/*.so* lib/ && \

--- a/object-detection/build_acap.sh
+++ b/object-detection/build_acap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/sh -eu
 
 [ $# -eq 1 ] || {
     echo "Argument should be: <APP_IMAGE>"

--- a/tensorflow-to-larod/build_env.sh
+++ b/tensorflow-to-larod/build_env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 docker build --build-arg http_proxy="${http_proxy:-}" \
              --build-arg https_proxy="${https_proxy:-}" \

--- a/tensorflow-to-larod/env/Dockerfile
+++ b/tensorflow-to-larod/env/Dockerfile
@@ -16,7 +16,7 @@ RUN git checkout ${libyuv_version}
 COPY yuv/*.patch /opt/build/libyuv
 RUN git apply ./*.patch && \
     CXXFLAGS=' -O2 -mthumb -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9 -fomit-frame-pointer' \
-    make -f linux.mk CXX=arm-linux-gnueabihf-g++ CC=arm-linux-gnueabihf-gcc && \
+    make -j -f linux.mk CXX=arm-linux-gnueabihf-g++ CC=arm-linux-gnueabihf-gcc && \
     arm-linux-gnueabihf-strip --strip-unneeded libyuv.so*
 
 # Copy the library to application folder

--- a/tensorflow-to-larod/env/build_acap.sh
+++ b/tensorflow-to-larod/env/build_acap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/sh -eu
 
 [ $# -eq 1 ] || {
     echo "Argument should be: <APP_IMAGE>"

--- a/tensorflow-to-larod/run_env.sh
+++ b/tensorflow-to-larod/run_env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 # Make sure a environment name was given
 [ $# -eq 1 ] || {

--- a/using-opencv/Dockerfile
+++ b/using-opencv/Dockerfile
@@ -59,7 +59,7 @@ RUN cmake -D CMAKE_TOOLCHAIN_FILE=../platforms/linux/arm-gnueabi.toolchain.cmake
     -D OPENCV_GENERATE_PKGCONFIG=ON \
     .. && \
     # Build openCV libraries and other tools
-    make -j 2 install
+    make -j "$(nproc)" install
 
 COPY app/ /opt/app
 WORKDIR /opt/app

--- a/vdo-larod/Dockerfile
+++ b/vdo-larod/Dockerfile
@@ -16,7 +16,7 @@ RUN git checkout ${libyuv_version}
 COPY yuv/*.patch /opt/build/libyuv
 RUN git apply ./*.patch && \
     CXXFLAGS=' -O2 -mthumb -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9 -fomit-frame-pointer' \
-    make -f linux.mk CXX=arm-linux-gnueabihf-g++ CC=arm-linux-gnueabihf-gcc && \
+    make -j -f linux.mk CXX=arm-linux-gnueabihf-g++ CC=arm-linux-gnueabihf-gcc && \
     arm-linux-gnueabihf-strip --strip-unneeded libyuv.so*
 
 # Copy the library to application folder


### PR DESCRIPTION
More portable to use `/bin/sh` instead of `/bin/bash` (and no need to launch
huge bash on systems that have smaller POSIX shells as `/bin/sh`, like
e.g. contemporary default Debian installations).

Also let make build in parallel to make use of multicore CPUs to improve
build times where applicable.