### PR TITLE
Add SHFMT linter and parallelize builds

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+[*]
+# Unix-style newlines at the bottom of every file
+end_of_line = lf
+charset = utf-8
+
+# Remove any whitespace characters preceding newline characters
+trim_trailing_whitespace = true
+
+[*.sh]
+# Tab indentation
+indent_style = space
+indent_size = 2
+switch_case_indent = true
+keep_padding       = true
+space_redirects    = true
+

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,6 +28,7 @@ jobs:
           VALIDATE_BASH: true
           VALIDATE_DOCKERFILE_HADOLINT: true
           VALIDATE_MARKDOWN: true
+          VALIDATE_SHELL_SHFMT: true
           VALIDATE_YAML: true
 
       - name: Check that linter symbolic links exist in top directory

--- a/LINT.md
+++ b/LINT.md
@@ -29,6 +29,7 @@ docker run --rm \
   -e VALIDATE_BASH=true \
   -e VALIDATE_DOCKERFILE_HADOLINT=true \
   -e VALIDATE_MARKDOWN=true \
+  -e VALIDATE_SHELL_SHFMT=true \
   -e VALIDATE_YAML=true \
   github/super-linter:slim-v4
 ```
@@ -61,6 +62,7 @@ yamllint -c .yamllint.yml .
 
 # Lint shell script files
 shellcheck $(shfmt -f .)
+shfmt -d .
 ```
 
 To lint only a specific file, replace `.` or `$(COMMAND)` with the file path.

--- a/larod/extract_analyze_output.sh
+++ b/larod/extract_analyze_output.sh
@@ -3,7 +3,7 @@
 # This is a helper script for analyzing and visualizing the
 # output from running this example on an Axis device.
 
-# Usage: 
+# Usage:
 # $1   -----   <IP-ADRESS of device>
 # $2   -----   <path to matching labelsfile for classification>
 #
@@ -47,9 +47,9 @@ while [ -z "$eof" ]; do
         # Get the class from the labels file
         class=$(awk 'NR=='$line'' "$2")
         # Recalculate as a probability percentage
-        prob=$(((value/255)*100 ))
+        prob=$(((value / 255) * 100))
         # Print the result
         echo "The model has found that with a probability of $prob % the picture represents a $class"
     fi
-fi
+  fi
 done < result.txt

--- a/object-detection/Dockerfile
+++ b/object-detection/Dockerfile
@@ -16,7 +16,7 @@ RUN git checkout ${libyuv_version}
 COPY yuv/*.patch /opt/build/libyuv
 RUN git apply ./*.patch && \
     CXXFLAGS=' -O2 -mthumb -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9 -fomit-frame-pointer' \
-    make -f linux.mk CXX=arm-linux-gnueabihf-g++ CC=arm-linux-gnueabihf-gcc && \
+    make -j -f linux.mk CXX=arm-linux-gnueabihf-g++ CC=arm-linux-gnueabihf-gcc && \
     arm-linux-gnueabihf-strip --strip-unneeded libyuv.so*
 
 # Build libjpeg-turbo
@@ -28,7 +28,7 @@ RUN git clone --branch 2.0.6 https://github.com/libjpeg-turbo/libjpeg-turbo.git
 WORKDIR /opt/build/libjpeg-turbo/build
 RUN CFLAGS=' -O2 -mthumb -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9 -fomit-frame-pointer' \
     CC=arm-linux-gnueabihf-gcc cmake -G"Unix Makefiles" .. && \
-    make
+    make -j
 WORKDIR /opt/app
 RUN mkdir -p lib include && \
     cp /opt/build/libjpeg-turbo/build/*.so* lib/ && \

--- a/object-detection/build_acap.sh
+++ b/object-detection/build_acap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/sh -eu
 
 [ $# -eq 1 ] || {
     echo "Argument should be: <APP_IMAGE>"

--- a/reproducible-package/reproducible_package.sh
+++ b/reproducible-package/reproducible_package.sh
@@ -58,8 +58,7 @@ clean_reproducible_test_env() {
   local dockrepo=rep
   local builddir=build
 
-  for i in 1 2 3
-  do
+  for i in 1 2 3; do
     echo "Remove build direcory: ${builddir}$i"
     [ -d ${builddir}$i ] && rm -rf ${builddir}$i
 
@@ -67,7 +66,6 @@ clean_reproducible_test_env() {
     docker image rm -f ${dockrepo}:$i
   done
 }
-
 
 #-------------------------------------------------------------------------------
 # Options
@@ -88,4 +86,3 @@ case $1 in
     exit 0
     ;;
 esac
-

--- a/tensorflow-to-larod/build_env.sh
+++ b/tensorflow-to-larod/build_env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 docker build --build-arg http_proxy="${http_proxy:-}" \
              --build-arg https_proxy="${https_proxy:-}" \

--- a/tensorflow-to-larod/env/Dockerfile
+++ b/tensorflow-to-larod/env/Dockerfile
@@ -16,7 +16,7 @@ RUN git checkout ${libyuv_version}
 COPY yuv/*.patch /opt/build/libyuv
 RUN git apply ./*.patch && \
     CXXFLAGS=' -O2 -mthumb -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9 -fomit-frame-pointer' \
-    make -f linux.mk CXX=arm-linux-gnueabihf-g++ CC=arm-linux-gnueabihf-gcc && \
+    make -j -f linux.mk CXX=arm-linux-gnueabihf-g++ CC=arm-linux-gnueabihf-gcc && \
     arm-linux-gnueabihf-strip --strip-unneeded libyuv.so*
 
 # Copy the library to application folder

--- a/tensorflow-to-larod/env/build_acap.sh
+++ b/tensorflow-to-larod/env/build_acap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/sh -eu
 
 [ $# -eq 1 ] || {
     echo "Argument should be: <APP_IMAGE>"

--- a/tensorflow-to-larod/run_env.sh
+++ b/tensorflow-to-larod/run_env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 # Make sure a environment name was given
 [ $# -eq 1 ] || {

--- a/using-opencv/Dockerfile
+++ b/using-opencv/Dockerfile
@@ -59,7 +59,7 @@ RUN cmake -D CMAKE_TOOLCHAIN_FILE=../platforms/linux/arm-gnueabi.toolchain.cmake
     -D OPENCV_GENERATE_PKGCONFIG=ON \
     .. && \
     # Build openCV libraries and other tools
-    make -j 2 install
+    make -j "$(nproc)" install
 
 COPY app/ /opt/app
 WORKDIR /opt/app

--- a/vdo-larod/Dockerfile
+++ b/vdo-larod/Dockerfile
@@ -16,7 +16,7 @@ RUN git checkout ${libyuv_version}
 COPY yuv/*.patch /opt/build/libyuv
 RUN git apply ./*.patch && \
     CXXFLAGS=' -O2 -mthumb -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9 -fomit-frame-pointer' \
-    make -f linux.mk CXX=arm-linux-gnueabihf-g++ CC=arm-linux-gnueabihf-gcc && \
+    make -j -f linux.mk CXX=arm-linux-gnueabihf-g++ CC=arm-linux-gnueabihf-gcc && \
     arm-linux-gnueabihf-strip --strip-unneeded libyuv.so*
 
 # Copy the library to application folder


### PR DESCRIPTION
Add SHFMT linter and update format of shell scripts. Some straightforward
scripts have been converted to use /bin/sh instead of bash.

Also let make build in parallel to make use of multicore CPUs to improve
build times where applicable.

Close #140