### PR TITLE
Update examples using VDO to make correct unref

### DIFF
--- a/object-detection/app/imgprovider.c
+++ b/object-detection/app/imgprovider.c
@@ -426,6 +426,7 @@ static void* threadEntry(void* data) {
                 g_clear_error(&error);
             }
         }
+        g_object_unref(newBuffer); // Release the ref from vdo_stream_get_buffer
         pthread_cond_signal(&provider->frameDeliverCond);
         pthread_mutex_unlock(&provider->frameMutex);
     }

--- a/tensorflow-to-larod-artpec8/env/app/imgprovider.c
+++ b/tensorflow-to-larod-artpec8/env/app/imgprovider.c
@@ -426,6 +426,7 @@ static void* threadEntry(void* data) {
                 g_clear_error(&error);
             }
         }
+        g_object_unref(newBuffer); // Release the ref from vdo_stream_get_buffer
         pthread_cond_signal(&provider->frameDeliverCond);
         pthread_mutex_unlock(&provider->frameMutex);
     }

--- a/tensorflow-to-larod/env/app/imgprovider.c
+++ b/tensorflow-to-larod/env/app/imgprovider.c
@@ -426,6 +426,7 @@ static void* threadEntry(void* data) {
                 g_clear_error(&error);
             }
         }
+        g_object_unref(newBuffer); // Release the ref from vdo_stream_get_buffer
         pthread_cond_signal(&provider->frameDeliverCond);
         pthread_mutex_unlock(&provider->frameMutex);
     }

--- a/using-opencv/app/imgprovider.cpp
+++ b/using-opencv/app/imgprovider.cpp
@@ -421,6 +421,7 @@ static void* threadEntry(void* data) {
                 g_clear_error(&error);
             }
         }
+        g_object_unref(newBuffer); // Release the ref from vdo_stream_get_buffer
         pthread_cond_signal(&provider->frameDeliverCond);
         pthread_mutex_unlock(&provider->frameMutex);
     }

--- a/vdo-larod-preprocessing/app/imgprovider.c
+++ b/vdo-larod-preprocessing/app/imgprovider.c
@@ -426,6 +426,7 @@ static void* threadEntry(void* data) {
                 g_clear_error(&error);
             }
         }
+        g_object_unref(newBuffer); // Release the ref from vdo_stream_get_buffer
         pthread_cond_signal(&provider->frameDeliverCond);
         pthread_mutex_unlock(&provider->frameMutex);
     }

--- a/vdo-larod/app/imgprovider.c
+++ b/vdo-larod/app/imgprovider.c
@@ -426,6 +426,7 @@ static void* threadEntry(void* data) {
                 g_clear_error(&error);
             }
         }
+        g_object_unref(newBuffer); // Release the ref from vdo_stream_get_buffer
         pthread_cond_signal(&provider->frameDeliverCond);
         pthread_mutex_unlock(&provider->frameMutex);
     }


### PR DESCRIPTION
Need to release the ref from vdo_stream_get_buffer for the other buffer.

It's no longer recommended to use VDO_BUFFER_STRATEGY_EXPLICIT, instead
the default strategy INFINITE is preferred if possible. This is not
fixed in this commit.

Reference: AFT-273
