### PR TITLE
Fix bug with isolation of openssl lib

### DIFF
--- a/utility-libraries/openssl_curl_example/Dockerfile
+++ b/utility-libraries/openssl_curl_example/Dockerfile
@@ -36,7 +36,7 @@ WORKDIR ${SDK_LIB_PATH_BASE}/lib
 RUN [ -z "$(ls libcrypto.so* libssl.so*)" ] || \
     rm -f libcrypto.so* libssl.so*
 
-WORKDIR ${SDK_LIB_PATH_BASE}/lib/pkgcpnfig
+WORKDIR ${SDK_LIB_PATH_BASE}/lib/pkgconfig
 RUN [ -z "$(ls libssl.pc libcrypto.pc openssl.pc)" ] || \
     rm -f libssl.pc libcrypto.pc openssl.pc
 


### PR DESCRIPTION
The pkgconfig folder was misspelled which means that the crypto and ssl package config files were left in the SDK root while the actual header files and library files were removed.

### Describe your changes

Correct symbol name

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
