### PR TITLE
openssl_curl_example: Improve build procedure

### DIFF
--- a/utility-libraries/openssl_curl_example/Dockerfile
+++ b/utility-libraries/openssl_curl_example/Dockerfile
@@ -29,20 +29,20 @@ ENV APP_DEBUG ${APP_DEBUG}
 # Prepare build environment
 #-------------------------------------------------------------------------------
 
-# Delete OpenSSL libraries in SDK to avoid linking to them in build time. This
-# is a safety precaution since all shared libraries should use the libc version
-# from the SDK in build time.
+# Delete OpenSSL and curl libraries in SDK to avoid linking to them in build
+# time. This is a safety precaution since all shared libraries should use the
+# libc version from the SDK in build time.
 WORKDIR ${SDK_LIB_PATH_BASE}/lib
-RUN [ -z "$(ls libcrypto.so* libssl.so*)" ] || \
-    rm -f libcrypto.so* libssl.so*
+RUN [ -z "$(ls libcrypto.so* libssl.so* libcurl.so*)" ] || \
+    rm -f libcrypto.so* libssl.so* libcurl.so*
 
 WORKDIR ${SDK_LIB_PATH_BASE}/lib/pkgconfig
-RUN [ -z "$(ls libssl.pc libcrypto.pc openssl.pc)" ] || \
-    rm -f libssl.pc libcrypto.pc openssl.pc
+RUN [ -z "$(ls libssl.pc libcrypto.pc openssl.pc libcurl.pc)" ] || \
+    rm -f libssl.pc libcrypto.pc openssl.pc libcurl.pc
 
 WORKDIR ${SDK_LIB_PATH_BASE}/include
-RUN [ -z "$(ls openssl crypto)" ] || \
-    rm -rf openssl crypto
+RUN [ -z "$(ls openssl crypto curl)" ] || \
+    rm -rf openssl crypto curl
 
 # Install build dependencies for cross compiling OpenSSL and curl
 RUN apt-get update && \
@@ -112,7 +112,12 @@ WORKDIR ${CURL_BUILD_DIR}
 RUN . /opt/axis/acapsdk/environment-setup* && \
     autoreconf -fi && \
     LDFLAGS="${LDFLAGS} -Wl,-rpath,${APP_RPATH}/lib" \
-    ./configure --prefix="${CURL_INSTALL_DIR}" ${CONFIGURE_FLAGS} --with-openssl && \
+    ./configure \
+      --with-openssl \
+      --without-zlib \
+      --without-zstd \
+      --prefix="${CURL_INSTALL_DIR}" \
+      ${CONFIGURE_FLAGS} && \
     make && \
     make install
 

--- a/utility-libraries/openssl_curl_example/README.md
+++ b/utility-libraries/openssl_curl_example/README.md
@@ -248,10 +248,9 @@ head -50 /var/log/info.log
 ## Outline of build steps
 
 1. **Prepare build environment** - We want to build all libraries with the
-   `libc` version of the SDK and avoid using `libssl` or `libcrypto`, which are
-also available in the SDK, by accident.  To achieve this, we recommend removing
-the OpenSSL libraries in the SDK library path. You don't need to remove curl
-since it's not included in the SDK.
+   `libc` version of the SDK and avoid using `libssl`, `libcrypto` or `libcurl`
+which are also available in the SDK, by accident.  To achieve this, we
+recommend removing any OpenSSL or curl libraries in the SDK library path.
 
    Why not remove these libraries from the SDK? The [Licensekey
 API](https://help.axis.com/acap-3-developer-guide#license-api)
@@ -334,7 +333,9 @@ objdump -p openssl_curl_example | grep -E "NEEDED|RUNPATH|RPATH"
 ```
 
 > **IMPORTANT**
-> Make sure SSH is enabled on the device before running the following commands.
+> Make sure [SSH is
+> enabled](../../FAQs.md#how-can-i-enable-ssh-on-an-axis-device) on the device
+> to run the following commands.
 
 For even better information on where the application binary will search for
 dependencies, SSH in to the device, and check the installed application binary
@@ -349,9 +350,6 @@ ldd:  libssl.so.1.1 => /usr/local/packages/openssl_curl_example/lib/libssl.so.1.
  libcurl.so.4 => /usr/local/packages/openssl_curl_example/lib/libcurl.so.4 (0x76c95000)
  libc.so.6 => /usr/lib/libc.so.6 (0x76b9a000)
  /lib/ld-linux-armhf.so.3 => /usr/lib/ld-linux-armhf.so.3 (0x76f22000)
- libpthread.so.0 => /usr/lib/libpthread.so.0 (0x76b75000)
- libdl.so.2 => /usr/lib/libdl.so.2 (0x76b62000)
- libz.so.1 => /usr/lib/libz.so.1 (0x76b42000)
 ```
 
 Here you can see that the application binary uses the bundled libraries.


### PR DESCRIPTION
Prevent possible additions of libraries in the SDK sysroot.

The curl build procedure using automake checks the environment and
automatically depends on some libs that it can find in the SDK sysroot,
like zlib and zstd used for compression of transferred data over HTTP.
Some libcurl build dependencies like these that are not necessary for
the example have been skipped via configure options.

Reference: ECODEVT-303