### PR TITLE
set width and height for vdostream incorrectly

### DIFF
--- a/vdostream/app/vdoencodeclient.c
+++ b/vdostream/app/vdoencodeclient.c
@@ -180,12 +180,14 @@ main(int argc, char* argv[])
     }
 
     VdoMap *settings = vdo_map_new();
-    if (!set_format(settings, format, &error))
-        goto exit;
 
     // Set default arguments
     vdo_map_set_uint32(settings, "width",  640);
     vdo_map_set_uint32(settings, "height", 360);
+
+    if (!set_format(settings, format, &error))
+        goto exit;
+
 
     // Create a new stream
     stream = vdo_stream_new(settings, NULL, &error);


### PR DESCRIPTION
### Describe your changes
I use your example vdostream, I tried to change width and height for vdostream but it didn't work
I found that your code made the setting incorrect order

### Checklist before requesting a review

- [ x ] I have performed a self-review of my own code
- [ x ] I have verified that the code builds perfectly fine on my local system
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have verified that my code follows the style already available in the repository
- [ x ] I have made corresponding changes to the documentation
